### PR TITLE
ingest fedora version of appimage for camera support and set icon for PWA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ ENV TITLE=BambuStudio \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 RUN \
+  echo "**** add icon ****" && \
+  curl -o \
+    /kclient/public/icon.png \
+    https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bambustudio-logo.png && \
   echo "**** install packages ****" && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
@@ -32,6 +36,7 @@ RUN \
     libgstreamer1.0 \
     libgstreamer-plugins-bad1.0 \
     libgstreamer-plugins-base1.0 \
+    libosmesa6 \
     libwebkit2gtk-4.0-37 \
     libwx-perl && \
   echo "**** install bambu studio from appimage ****" && \
@@ -40,7 +45,7 @@ RUN \
     | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   RELEASE_URL=$(curl -sX GET "https://api.github.com/repos/bambulab/BambuStudio/releases/latest"     | awk '/url/{print $4;exit}' FS='[""]') && \
-  DOWNLOAD_URL=$(curl -sX GET "${RELEASE_URL}" | awk '/browser_download_url.*ubuntu/{print $4;exit}' FS='[""]') && \
+  DOWNLOAD_URL=$(curl -sX GET "${RELEASE_URL}" | awk '/browser_download_url.*fedora/{print $4;exit}' FS='[""]') && \
   cd /tmp && \
   curl -o \
     /tmp/bambu.app -L \

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This container is based on [Docker Baseimage KasmVNC](https://github.com/linuxse
 | FM_HOME | This is the home directory (landing) for the file manager, default "/config". |
 | START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup. |
 | DRINODE | If mounting in /dev/dri for [DRI3 GPU Acceleration](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html) allows you to specify the device to use IE `/dev/dri/renderD128` |
+| LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
 
 #### Optional run configurations
 
@@ -311,4 +312,5 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **08.02.24:** - Fix printer camera by ingesting Fedora Appimage, Add program icon for PWA ingestion.
 * **15.11.23:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -57,6 +57,7 @@ app_setup_block: |
   | FM_HOME | This is the home directory (landing) for the file manager, default "/config". |
   | START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup. |
   | DRINODE | If mounting in /dev/dri for [DRI3 GPU Acceleration](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html) allows you to specify the device to use IE `/dev/dri/renderD128` |
+  | LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
 
   #### Optional run configurations
 
@@ -73,4 +74,5 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "08.02.24:", desc: "Fix printer camera by ingesting Fedora Appimage, Add program icon for PWA ingestion." }
   - { date: "15.11.23:", desc: "Initial release." }


### PR DESCRIPTION
In this thread we discovered that the Fedora version of the Appimage does not have broken deps and this fixes webcam and remote control. 

https://github.com/linuxserver/docker-orcaslicer/issues/3

I also added the logic to ingest the correct icon for the app being installed as a PWA. 