### PR TITLE
#15 #14 add env var for dark mode and install required fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \
     firefox-esr \
+    fonts-dejavu \
+    fonts-dejavu-extra \
     gstreamer1.0-alsa \
     gstreamer1.0-gl \
     gstreamer1.0-gtk3 \

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
+      - DARK_MODE=true #optional
     volumes:
       - /path/to/config:/config
     ports:
@@ -146,6 +147,7 @@ docker run -d \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Etc/UTC \
+  -e DARK_MODE=true `#optional` \
   -p 3000:3000 \
   -p 3001:3001 \
   -v /path/to/config:/config \
@@ -164,6 +166,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
+| `-e DARK_MODE=true` | Set this to true to enable dark mode for Bambu Studio. |
 | `-v /config` | Users home directory in the container, stores program settings and files. |
 | `--security-opt seccomp=unconfined` | For Docker Engine only, many modern gui apps need this to function on older hosts as syscalls are unknown to Docker. |
 
@@ -328,6 +331,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **29.07.24:** - Add required fonts and environment variable for dark mode.
 * **10.02.24:** - Update Readme with new env vars.
 * **08.02.24:** - Fix printer camera by ingesting Fedora Appimage, Add program icon for PWA ingestion.
 * **15.11.23:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -18,9 +18,9 @@ development_versions: false
 # container parameters
 common_param_env_vars_enabled: true
 param_container_name: "{{ project_name }}"
-param_usage_include_env: true
-param_env_vars:
-  - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "DARK_MODE", env_value: "true", desc: "Set this to true to enable dark mode for Bambu Studio." }
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/config", desc: "Users home directory in the container, stores program settings and files." }
@@ -90,6 +90,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "29.07.24:", desc: "Add required fonts and environment variable for dark mode." }
   - { date: "10.02.24:", desc: "Update Readme with new env vars." }
   - { date: "08.02.24:", desc: "Fix printer camera by ingesting Fedora Appimage, Add program icon for PWA ingestion." }
   - { date: "15.11.23:", desc: "Initial release." }

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,10 @@
+# Enable dark mode if defined
+if [ "${DARK_MODE}" = "true" ] && [ ! -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
+  mkdir -p $HOME/.config/gtk-3.0
+  echo '[Settings]' > $HOME/.config/gtk-3.0/settings.ini
+  echo 'gtk-application-prefer-dark-theme=1' >> $HOME/.config/gtk-3.0/settings.ini
+elif [ "${DARK_MODE}" != "true" ] && [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
+  rm -f "$HOME/.config/gtk-3.0/settings.ini"
+fi
+
 /opt/bambustudio/AppRun


### PR DESCRIPTION
This sets the GTK theme to dark with an env variable and adds fonts needed for Bambu Studio. 