### PR TITLE
rebase to noble ingest real firefox from xtradeb

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -111,7 +111,7 @@ jobs:
             exit 0
           else
             assets=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/bambulab/BambuStudio/releases/tags/${EXT_RELEASE}" | jq -r '.assets[].browser_download_url')
-            if grep -q "Bambu_Studio_linux_fedora" <<< "${assets}"; then
+            if grep -q "Bambu_Studio_linux_ubuntu-24.04" <<< "${assets}"; then
               artifacts_found="true"
             else
               artifacts_found="false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,7 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bambustudio-logo.png && \
   echo "**** install packages ****" && \
-  apt-key adv \
-    --keyserver hkp://keyserver.ubuntu.com:80 \
-    --recv-keys 5301FA4FD93244FBC6F6149982BB6851C64F6880 && \
-  echo \
-    "deb https://ppa.launchpadcontent.net/xtradeb/apps/ubuntu noble main" > \
-    /etc/apt/sources.list.d/xtradeb.list && \
+  add-apt-repository ppa:xtradeb/apps && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:debianbookworm
+FROM ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
 
 # set version label
 ARG BUILD_DATE
@@ -19,10 +19,16 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bambustudio-logo.png && \
   echo "**** install packages ****" && \
+  apt-key adv \
+    --keyserver hkp://keyserver.ubuntu.com:80 \
+    --recv-keys 5301FA4FD93244FBC6F6149982BB6851C64F6880 && \
+  echo \
+    "deb https://ppa.launchpadcontent.net/xtradeb/apps/ubuntu noble main" > \
+    /etc/apt/sources.list.d/xtradeb.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \
-    firefox-esr \
+    firefox \
     fonts-dejavu \
     fonts-dejavu-extra \
     gir1.2-gst-plugins-bad-1.0 \
@@ -31,7 +37,7 @@ RUN \
     gstreamer1.0-plugins-* \
     gstreamer1.0-pulseaudio \
     libosmesa6 \
-    libwebkit2gtk-4.0-37 \
+    libwebkit2gtk-4.1-0 \
     libwx-perl && \
   echo "**** install bambu studio from appimage ****" && \
   if [ -z ${BAMBUSTUDIO_VERSION+x} ]; then \
@@ -39,7 +45,7 @@ RUN \
     | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   RELEASE_URL=$(curl -sX GET "https://api.github.com/repos/bambulab/BambuStudio/releases/latest"     | awk '/url/{print $4;exit}' FS='[""]') && \
-  DOWNLOAD_URL=$(curl -sX GET "${RELEASE_URL}" | awk '/browser_download_url.*fedora/{print $4;exit}' FS='[""]') && \
+  DOWNLOAD_URL=$(curl -sX GET "${RELEASE_URL}" | awk '/browser_download_url.*24.04/{print $4;exit}' FS='[""]') && \
   cd /tmp && \
   curl -o \
     /tmp/bambu.app -L \

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **14.08.25:** - Rebase to Ubuntu Noble to ingest approved appimage.
 * **12.07.25:** - Rebase to Selkies, HTTPS IS NOW REQUIRED.
 * **29.07.24:** - Add required fonts and environment variable for dark mode.
 * **10.02.24:** - Update Readme with new env vars.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -8,7 +8,7 @@ release_tag: latest
 ls_branch: master
 external_artifact_check: |
   assets=$(curl -u "${{ '{{' }} secrets.CR_USER {{ '}}' }}:${{ '{{' }} secrets.CR_PAT {{ '}}' }}" -sX GET "https://api.github.com/repos/bambulab/BambuStudio/releases/tags/${EXT_RELEASE}" | jq -r '.assets[].browser_download_url')
-  if grep -q "Bambu_Studio_linux_fedora" <<< "${assets}"; then
+  if grep -q "Bambu_Studio_linux_ubuntu-24.04" <<< "${assets}"; then
     artifacts_found="true"
   else
     artifacts_found="false"

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -104,6 +104,7 @@ init_diagram: |
   "bambustudio:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "14.08.25:", desc: "Rebase to Ubuntu Noble to ingest approved appimage."}
   - {date: "12.07.25:", desc: "Rebase to Selkies, HTTPS IS NOW REQUIRED."}
   - {date: "29.07.24:", desc: "Add required fonts and environment variable for dark mode."}
   - {date: "10.02.24:", desc: "Update Readme with new env vars."}

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -2,7 +2,7 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
-<item label="FireFox" icon="/usr/share/icons/hicolor/48x48/apps/firefox-esr.png"><action name="Execute"><command>/usr/bin/firefox</command></action></item>
+<item label="FireFox" icon="/usr/share/icons/hicolor/48x48/apps/firefox.png"><action name="Execute"><command>/usr/bin/firefox</command></action></item>
 <item label="Bambu Studio" icon="/opt/bambustudio/BambuStudio.png"><action name="Execute"><command>/opt/bambustudio/AppRun</command></action></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
No more fedora appimage and this is likely the one they are testing anyway, if i recall correctly we were using it because the remote printer control tab would crash the program previously. 

I checked ldd on the network and maker plugin that are installed by default and tried out some models with Nvidia and DRI3 also logging in, not much more I can test without a printer. 